### PR TITLE
Update manually-building-a-tile-server-ubuntu-24-04-lts.md

### DIFF
--- a/serving-tiles/manually-building-a-tile-server-ubuntu-24-04-lts.md
+++ b/serving-tiles/manually-building-a-tile-server-ubuntu-24-04-lts.md
@@ -176,7 +176,7 @@ Since version v5.3.0, some extra indexes now need to be [applied manually](https
     cd ~/src/openstreetmap-carto/
     sudo -u _renderd psql -d gis -f indexes.sql
     
-It should respond with "CREATE INDEX" 14 times.
+It should respond with "CREATE INDEX" 16 times.
 
 ## Shapefile download
 


### PR DESCRIPTION
There are 16 commands now: https://github.com/gravitystorm/openstreetmap-carto/blob/master/indexes.sql